### PR TITLE
add getEstimateError

### DIFF
--- a/src/SimpleKalmanFilter.cpp
+++ b/src/SimpleKalmanFilter.cpp
@@ -44,3 +44,6 @@ float SimpleKalmanFilter::getKalmanGain() {
   return _kalman_gain;
 }
 
+float SimpleKalmanFilter::getEstimateError() {
+  return _err_estimate;
+}

--- a/src/SimpleKalmanFilter.cpp
+++ b/src/SimpleKalmanFilter.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * SimpleKalmanFilter - a Kalman Filter implementation for single variable models.
  * Created by Denys Sene, January, 1, 2017.
  * Released under MIT License - see LICENSE file for details.

--- a/src/SimpleKalmanFilter.h
+++ b/src/SimpleKalmanFilter.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * SimpleKalmanFilter - a Kalman Filter implementation for single variable models.
  * Created by Denys Sene, January, 1, 2017.
  * Released under MIT License - see LICENSE file for details.
@@ -7,7 +7,7 @@
 #ifndef SimpleKalmanFilter_h
 #define SimpleKalmanFilter_h
 
-class SimpleKalmanFilter 
+class SimpleKalmanFilter
 {
 
 public:
@@ -17,7 +17,7 @@ public:
   void setEstimateError(float est_e);
   void setProcessNoise(float q);
   float getKalmanGain();
-  
+
 private:
   float _err_measure;
   float _err_estimate;
@@ -25,7 +25,7 @@ private:
   float _current_estimate;
   float _last_estimate;
   float _kalman_gain;
-  
+
 };
 
 #endif

--- a/src/SimpleKalmanFilter.h
+++ b/src/SimpleKalmanFilter.h
@@ -17,6 +17,7 @@ public:
   void setEstimateError(float est_e);
   void setProcessNoise(float q);
   float getKalmanGain();
+  float getEstimateError();
 
 private:
   float _err_measure;


### PR DESCRIPTION
In order to understand better what happens inside the Kalman filter an output of the estimated error is helpful. It helps to determine start settings for a specific filter.