### PR TITLE
Stuck at 0, if dynamically allocated and fed 0s

### DIFF
--- a/src/SimpleKalmanFilter.h
+++ b/src/SimpleKalmanFilter.h
@@ -23,9 +23,9 @@ private:
   float _err_measure;
   float _err_estimate;
   float _q;
-  float _current_estimate;
-  float _last_estimate;
-  float _kalman_gain;
+  float _current_estimate = 0;
+  float _last_estimate = 0;
+  float _kalman_gain = 0;
 
 };
 


### PR DESCRIPTION
First of all, thanks for the great library!

I encountered problems in the following conditions:
- filter is dynamically created
- initially updated with 0's

The gain will go to 0 and will forever remain 0.
This is why pots are getting stuck at 0 if set at 0 during startup.

With the fix, even feeding 2,000,000 zeros, gain is 0.5.
Only _last_estimate needs to be initialized, but user can call getKalmanGain(),
so for consistency initialize it also.

Example Code:
```
SimpleKalmanFilter kf[3] = {
    SimpleKalmanFilter( 2, 2, 0.1 ), 
    SimpleKalmanFilter( 2, 2, 0.1 ),
    SimpleKalmanFilter( 2, 2, 0.1 ) };
SimpleKalmanFilter *pkf[3];
for( int i = 0 ; i < 3 ; i++ ) {
    pkf[ i ] = new SimpleKalmanFilter( 2, 2, 0.1 ); }

// update 20x with 0, then 20x with 100
for( int i = 0 ; i < 3 ; i++ ) {
    for( int j = 0 ; j < 20 ; j++ ) {
        kf[ i ].updateEstimate( 0 );
        pkf[ i ]->updateEstimate( 0 );
    }
    for( int j = 0 ; j < 20 ; j++ ) {
        kf[ i ].updateEstimate( 100 );
        pkf[ i ]->updateEstimate( 100 );
    }
}    
Serial.println( "Gain:" );
for( int i = 0 ; i < 3 ; i++ ) {
    Serial.println( kf[i].getKalmanGain() * 1000000 );
    Serial.println( pkf[i]->getKalmanGain() * 1000000 );
}
Serial.println( "Update:" );
for( int i = 0 ; i < 3 ; i++ ) {
    Serial.println( kf[i].updateEstimate( 100 ) );
    Serial.println( pkf[i]->updateEstimate( 100 ) );
}
```
Result:
```
Gain:
71466.38
71466.38
71466.38
0.00
71466.38
0.00
Update:
99.86
99.86
99.86
0.00
99.86
0.00
```