### PR TITLE
Remove implicit conversion

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/denyssene/SimpleKalmanFilter.git"
   },
-  "version": "0.1.0",
+  "version": "0.1.1",
   "authors": {
     "name": "Denys Sene",
     "url": ""

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SimpleKalmanFilter
-version=0.1
+version=0.1.1
 author=Denys Sene
 maintainer=Denys Sene
 sentence=A simple implementation of Kalman Filter.

--- a/src/SimpleKalmanFilter.cpp
+++ b/src/SimpleKalmanFilter.cpp
@@ -19,7 +19,7 @@ float SimpleKalmanFilter::updateEstimate(float mea)
 {
   _kalman_gain = _err_estimate/(_err_estimate + _err_measure);
   _current_estimate = _last_estimate + _kalman_gain * (mea - _last_estimate);
-  _err_estimate =  (1.0 - _kalman_gain)*_err_estimate + fabs(_last_estimate-_current_estimate)*_q;
+  _err_estimate =  (1.0f - _kalman_gain)*_err_estimate + fabsf(_last_estimate-_current_estimate)*_q;
   _last_estimate=_current_estimate;
 
   return _current_estimate;


### PR DESCRIPTION
Currently, there are two implicit conversions that cause the results to be upcast and then downcasted. On embedded systems, this has unforeseen side effects where the operations cant utilise the cores FPU since some only work on single precision. 

This change replaces fabs which takes a double and returns a double with fabsf, which takes a float and returns a float. It also changes the double literal to a single literal to avoid an upcast on the subtraction. 