### PR TITLE
Set default values for `SimpleKalmanFilter` constructor parameters

### DIFF
--- a/src/SimpleKalmanFilter.h
+++ b/src/SimpleKalmanFilter.h
@@ -9,23 +9,22 @@
 
 class SimpleKalmanFilter
 {
+  public:
+    SimpleKalmanFilter(float mea_e = 2, float est_e = 2, float q = 0.01);
+    float updateEstimate(float mea);
+    void  setMeasurementError(float mea_e);
+    void  setEstimateError(float est_e);
+    void  setProcessNoise(float q);
+    float getKalmanGain();
+    float getEstimateError();
 
-public:
-  SimpleKalmanFilter(float mea_e, float est_e, float q);
-  float updateEstimate(float mea);
-  void setMeasurementError(float mea_e);
-  void setEstimateError(float est_e);
-  void setProcessNoise(float q);
-  float getKalmanGain();
-  float getEstimateError();
-
-private:
-  float _err_measure;
-  float _err_estimate;
-  float _q;
-  float _current_estimate = 0;
-  float _last_estimate = 0;
-  float _kalman_gain = 0;
+  private:
+    float _err_measure;
+    float _err_estimate;
+    float _q;
+    float _current_estimate = 0;
+    float _last_estimate = 0;
+    float _kalman_gain = 0;
 };
 
 #endif


### PR DESCRIPTION
With default values for the `SimpleKalmanFilter` constructor (mea_e = 3.5, est_e = 3.5, q = 0.1), it is now possible to declare arrays of `SimpleKalmanFilter` objects without needing to pass parameters for each instance.

For example, the following declaration is now valid:
`SimpleKalmanFilter kalman_dist[64];`

This improves usability when creating multiple filter instances with the same default settings.